### PR TITLE
Update Build 8 Change List.md

### DIFF
--- a/Info/Build 8 Change List.md
+++ b/Info/Build 8 Change List.md
@@ -28,9 +28,8 @@ Note: All proposed changes are suggestions/ideas, until deemed final.
 __Homeworld 1__
 -Fixed a rules of engagement bug that caused many Turanic, Kadeshi, and Junkyard ships to sometimes stop attacking unexpectedly and behave passively.
 -Updated research costs to match multiplayer, and research times to 1.5x slower than multiplayer (the campaign research is slower paced). These hadn't been updated since HWR v1.0. Mission resources were also adjusted to support the changes.
+-Captured Turanic Standard Corvettes can now be repaired.
 -Captured Turanic Ion Array Frigates and Kadeshi Multi-beam Frigates can now be retired immediately.
-__Mission 2__
-Captured Turanic Heavy Corvettes can now be repaired.
 
 __Homeworld 2__
 -Fixed a rules of engagement bug that caused Keeper ships to sometimes stop attacking unexpectedly and behave passively.


### PR DESCRIPTION
In-game it's Standard Corvette, not Heavy. There is one file for Standard Corvettes, so if they can't be repaired in M02 they can't be repaired for the remaining of the campaign. It's not like the cryotrais that have two files, one for M01 (can't be salvaged) and one for M03 (can be salvaged) :)

Please change this in all the other relevant places (like Steam / Gearbox Forums / ModDB...)